### PR TITLE
fix: use correct file extension

### DIFF
--- a/languages/blade/config.toml
+++ b/languages/blade/config.toml
@@ -1,6 +1,6 @@
 name = "Blade"
 grammar = "blade"
-path_suffixes = ["*.blade.php"]
+path_suffixes = ["blade.php"]
 block_comment = ["{{-- ", " --}}"]
 autoclose_before = ";:.,=}])>"
 brackets = [


### PR DESCRIPTION
`path_suffix` [doesn't support glob matching](https://zed.dev/docs/extensions/languages#language-metadata), so this wasn't doing anything. (As far as I know, Zed supports globs for user defined file associations, but not extension-provided suffixes, like this.)

Zed still won't recognize this extension for `blade.php` because the internals still don't support "compound extensions", but an updated PR is in the works for that[^1], and – if landed – this would start working to automatically select this lang for `blade.php` files.

Thank you!

[^1]: I had attempted this once, [a year ago](#11697), but ran out of interest and time, but I just updated it and got it working again. I'm hoping to submit for consideration soon.


