### PR TITLE
Enable Tailwind CSS Completions for Blade

### DIFF
--- a/languages/blade/overrides.scm
+++ b/languages/blade/overrides.scm
@@ -1,0 +1,4 @@
+[
+  (quoted_attribute_value)
+  (attribute_value)
+] @string

--- a/languages/php_only/config.toml
+++ b/languages/php_only/config.toml
@@ -12,4 +12,8 @@ brackets = [
         "string",
     ] },
 ]
-hidden = true
+scope_opt_in_language_servers = ["tailwindcss-language-server"]
+
+[overrides.string]
+completion_query_characters = ["-"]
+opt_into_language_servers = ["tailwindcss-language-server"]

--- a/languages/php_only/overrides.scm
+++ b/languages/php_only/overrides.scm
@@ -1,0 +1,5 @@
+[
+  (encapsed_string)
+  (string)
+  (string_content)
+] @string


### PR DESCRIPTION
Enhances the development experience by enabling Tailwind CSS autocompletions across various scenarios in Blade templates. The following examples illustrate supported use cases:

```blade
<span class="bg-gray-100"></span>
<span @class(['bg-gray-100', 'text-red-600' => $hasError])></span>
<span {{ $attributes->class(['bg-gray-100', 'text-red-600' => $hasError]) }}></span>
<span {{ $attributes->merge(['class' => 'bg-gray-100 text-blue-600']) }}></span>
```

To get the autocompletions going, you'll need to set up the ⁠`tailwindcss-language-server` with some class regex rules.

```json
{
  "lsp": {
    "tailwindcss-language-server": {
      "settings": {
        "userLanguages": {
          "plaintext": "html",
          "blade": "html"
        },
        "experimental": {
          "classRegex": [
            [ "@?class\\(([^)]*)\\)", "['|\"]([^'\"]*)['|\"]" ],
            "(?:\"|')class(?:\"|')[\\s]*=>[\\s]*(?:\"|')([^\"']*)"
          ]
        },
        "emmetCompletions": false,
        "hovers": true,
        "suggestions": true,
        "validate": true
      }
    }
  }
}
```