### PR TITLE
feat: ✨ Added word_characters override for element and string nodes in Blade config.

### DIFF
--- a/languages/blade/config.toml
+++ b/languages/blade/config.toml
@@ -3,6 +3,7 @@ grammar = "blade"
 path_suffixes = ["blade.php"]
 block_comment = ["{{-- ", " --}}"]
 autoclose_before = ";:.,=}])>"
+word_characters = ["-"]
 brackets = [
     { start = "{", end = "}", close = true, newline = true },
     { start = "[", end = "]", close = true, newline = true },
@@ -19,6 +20,10 @@ scope_opt_in_language_servers = ["tailwindcss-language-server"]
 prettier_plugins = ["@shufo/prettier-plugin-blade"]
 prettier_parser_name = "blade"
 
+[overrides.element]
+word_characters = ["-"]
+
 [overrides.string]
+word_characters = ["-"]
 completion_query_characters = ["-"]
 opt_into_language_servers = ["tailwindcss-language-server"]

--- a/languages/blade/overrides.scm
+++ b/languages/blade/overrides.scm
@@ -1,3 +1,5 @@
+(element) @element
+
 [
   (quoted_attribute_value)
   (attribute_value)


### PR DESCRIPTION
## Add hyphenated word selection for Blade component names                                                                              
                                         
  ### Problem                                                                                                                             
                                                            
  In Blade templates, component names are hyphenated by convention: `<x-alert-dialog>`, `<livewire:user-settings>`, `<x-nav-link>`.       
  Currently, double-clicking on these names only selects a single segment (e.g., `alert` instead of `alert-dialog`), making it harder to
  select, copy, or refactor component names.

  This affects every Blade developer's daily workflow — selecting component names, attribute values like TailwindCSS classes
  (`text-gray-500`), and navigating between hyphenated identifiers.

  ### Solution

  Add `word_characters = ["-"]` so Zed treats hyphens as part of words in Blade files. This is configured at three levels for complete
  coverage:

  | Scope | What it covers |
  |---|---|
  | Root | Component tag names (`x-alert-dialog`), directive names, general text |
  | `element` | HTML element context — tag names, attribute names |
  | `string` | Attribute values — TailwindCSS classes, component references |

  The `element` scope required a corresponding `(element) @element` capture in `overrides.scm`, which is also included.

  ### Before & After

  | Action | Before | After |
  |---|---|---|
  | Double-click `alert` in `<x-alert-dialog>` | Selects `alert` | Selects `alert-dialog` |
  | Double-click `gray` in `text-gray-500` | Selects `gray` | Selects `text-gray-500` |
  | Double-click `user` in `<livewire:user-settings>` | Selects `user` | Selects `user-settings` |
  | `Cmd+D` to find-and-replace a component name | Requires manual selection | Double-click selects the full name |

  ### Why this matters for Laravel developers

  Laravel's ecosystem is built on hyphenated naming conventions:
  - **Blade components**: `<x-nav-link>`, `<x-dropdown-menu>`, `<x-form-input>`
  - **Livewire components**: `<livewire:user-profile>`, `<livewire:comment-list>`
  - **TailwindCSS** (used by most Laravel apps): `bg-blue-500`, `text-sm`, `rounded-lg`
  - **Alpine.js directives**: `x-data`, `x-show`, `x-transition`

  Without this change, every selection, rename, or copy operation on these names requires extra effort. With it, Blade files feel as
  natural to navigate as any other language in Zed.

  ### Changes

  - **`config.toml`**: Added `word_characters = ["-"]` at root scope and in `[overrides.element]` and `[overrides.string]`
  - **`overrides.scm`**: Added `(element) @element` capture to support the element scope override
  
-----

PS: I am submitting this as part of the improvements I had originally included in my Laravel extension, and is one piece in a collection of PRs I will be submitting for Blade improvements from my extension. The Zed team recommended I submit these improvements upstream to the Blade extension, so that our extension can leave side-by-side and mine does not override yours. Please let me know if you have any concerns or questions.