### PR TITLE
feat: rewrite syntax highlighting, add code folding and outline

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,12 @@ Optionally, create `.bladeformatterrc.json` in your project root to configure fo
 
 ```json
 {
-  "indent-size": 2,
-  "wrap-line-length": 120
+  "indentSize": 2,
+  "wrapLineLength": 120
 }
 ```
+
+> **Note:** Config keys must be **camelCase** (e.g. `indentSize`), not kebab-case. The CLI flags use `--indent-size`, but the JSON config file uses `indentSize`.
 
 ## Grammar
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,63 @@ Laravel Blade templating language support for [Zed](https://zed.dev).
 > }
 > ```
 
+## Features
+
+- Syntax highlighting for all Blade directives (conditionals, loops, sections, stacks, inline directives, keywords, attribute directives, Envoy, Livewire)
+- Code folding for `@if`/`@foreach`/`@section`/`@switch` and all block directives
+- Outline panel with section names, conditionals, loops, HTML elements
+- Language injections: PHP, JavaScript, CSS, Alpine.js, Livewire attributes
+- Auto-indentation for Blade blocks and HTML
+- Bracket matching and tag auto-close
+- Tailwind CSS IntelliSense opt-in
+- Prettier support via `@shufo/prettier-plugin-blade` (currently broken — see [zed#42796](https://github.com/zed-industries/zed/issues/42796))
+
+## Formatting
+
+Install [blade-formatter](https://github.com/shufo/blade-formatter) globally:
+
+```bash
+npm install -g blade-formatter
+```
+
+Then add to your Zed settings:
+
+```json
+{
+  "languages": {
+    "Blade": {
+      "formatter": {
+        "external": {
+          "command": "blade-formatter",
+          "arguments": ["--stdin"]
+        }
+      },
+      "format_on_save": "on"
+    }
+  }
+}
+```
+
+Optionally, create `.bladeformatterrc.json` in your project root to configure formatting:
+
+```json
+{
+  "indent-size": 2,
+  "wrap-line-length": 120
+}
+```
+
 ## Grammar
 
 - [tree-sitter-blade](https://github.com/EmranMR/tree-sitter-blade)
+
+## Language Servers
+
+The extension provides these language servers (at least one must be enabled in Zed settings):
+
+| Server | Description |
+|---|---|
+| **Intelephense** | PHP intelligence — autocompletion, go-to-definition, diagnostics |
+| **PhpTools** | DEVSENSE PHP Tools — commercial alternative to Intelephense |
+| **Phpactor** | Open-source PHP language server |
+| **Emmet** | Emmet abbreviations support inside Blade files |

--- a/languages/blade/config.toml
+++ b/languages/blade/config.toml
@@ -3,7 +3,7 @@ grammar = "blade"
 path_suffixes = ["blade.php"]
 block_comment = ["{{-- ", " --}}"]
 autoclose_before = ";:.,=}])>"
-word_characters = ["-"]
+word_characters = ["-", "@"]
 brackets = [
     { start = "{", end = "}", close = true, newline = true },
     { start = "[", end = "]", close = true, newline = true },
@@ -21,8 +21,6 @@ brackets = [
 ]
 wrap_characters = { start_prefix = "<", start_suffix = ">", end_prefix = "</", end_suffix = ">" }
 scope_opt_in_language_servers = ["tailwindcss-language-server"]
-prettier_plugins = ["@shufo/prettier-plugin-blade"]
-prettier_parser_name = "blade"
 
 [jsx_tag_auto_close]
 open_tag_node_name = "start_tag"

--- a/languages/blade/folds.scm
+++ b/languages/blade/folds.scm
@@ -1,0 +1,41 @@
+;; ============================================================
+;; Blade Block Directives — fold entire block
+;; ============================================================
+
+(conditional) @fold
+(loop) @fold
+(switch) @fold
+(section) @fold
+(stack) @fold
+(once) @fold
+(fragment) @fold
+(verbatim) @fold
+
+;; @php ... @endphp blocks
+(php_statement
+  (directive_start)
+  (directive_end)) @fold
+
+;; Envoy blocks
+(envoy) @fold
+
+;; Livewire blocks
+(livewire) @fold
+
+;; ============================================================
+;; HTML Elements
+;; ============================================================
+
+(element
+  (start_tag)
+  (end_tag)) @fold
+
+(script_element
+  (start_tag)
+  (raw_text)
+  (end_tag)) @fold
+
+(style_element
+  (start_tag)
+  (raw_text)
+  (end_tag)) @fold

--- a/languages/blade/highlights.scm
+++ b/languages/blade/highlights.scm
@@ -176,7 +176,7 @@
 ;; + any custom directives matching @[a-zA-Z]+
 ;; ============================================================
 
-(document (directive) @function.call)
+(directive) @function.call
 
 ;; ============================================================
 ;; Parameters (inside directive parentheses)

--- a/languages/blade/highlights.scm
+++ b/languages/blade/highlights.scm
@@ -1,4 +1,20 @@
 ;; ============================================================
+;; Catch-all: Inline Directives (lowest priority)
+;; @include @includeIf @includeWhen @includeUnless @includeFirst
+;; @extends @yield @method @inject @each @vite @livewire
+;; @aware @servers @import @js @svg @props @use @stack
+;; @asset @json @script @thumbnail @extract @set
+;; @wireUiScripts (with params)
+;; + any custom directives matching @[a-zA-Z]+
+;;
+;; NOTE: This must come BEFORE all specific directive rules.
+;; Tree-sitter gives later patterns higher priority, so
+;; specific rules below will override this catch-all.
+;; ============================================================
+
+(directive) @function.call
+
+;; ============================================================
 ;; HTML
 ;; ============================================================
 
@@ -30,9 +46,14 @@
 ;; @csrf @parent @inertia @inertiaHead @viteReactRefresh
 ;; @livewireStyles @livewireScripts @livewireScriptConfig
 ;; @routes @permalink @title @content @excerpt @wireUiScripts
+;;
+;; (keyword) wraps a single (directive) child — we capture
+;; the inner directive so this later pattern overrides the
+;; catch-all above.
 ;; ============================================================
 
-(keyword) @constant
+(keyword
+  (directive) @constant)
 
 ;; ============================================================
 ;; Conditionals — open/close
@@ -165,18 +186,6 @@
 
 (attribute
   (directive) @attribute)
-
-;; ============================================================
-;; Inline Directives — bare (directive) at document level
-;; @include @includeIf @includeWhen @includeUnless @includeFirst
-;; @extends @yield @method @inject @each @vite @livewire
-;; @aware @servers @import @js @svg @props @use @stack
-;; @asset @json @script @thumbnail @extract @set
-;; @field @options (ACF) @wireUiScripts (with params)
-;; + any custom directives matching @[a-zA-Z]+
-;; ============================================================
-
-(directive) @function.call
 
 ;; ============================================================
 ;; Parameters (inside directive parentheses)

--- a/languages/blade/highlights.scm
+++ b/languages/blade/highlights.scm
@@ -1,15 +1,21 @@
-; html
+;; ============================================================
+;; HTML
+;; ============================================================
+
 (tag_name) @tag
 (doctype) @tag.doctype
 (attribute_name) @attribute
+(entity) @string.special
+
 [
   "\""
   "'"
   (attribute_value)
 ] @string
+
 (comment) @comment
 
-"=" @punctuation.delimiter.html
+"=" @punctuation.delimiter
 
 [
   "<"
@@ -17,15 +23,171 @@
   "<!"
   "</"
   "/>"
-] @punctuation.bracket.html
+] @punctuation.bracket
 
-; blade
-(directive) @function
-(directive_start) @function
-(directive_end) @function
-(comment) @comment
-(attribute (directive) @function)
-(keyword) @function
+;; ============================================================
+;; Blade Keywords — standalone, no parameters
+;; @csrf @parent @inertia @inertiaHead @viteReactRefresh
+;; @livewireStyles @livewireScripts @livewireScriptConfig
+;; @routes @permalink @title @content @excerpt @wireUiScripts
+;; ============================================================
+
+(keyword) @constant
+
+;; ============================================================
+;; Conditionals — open/close
+;; @if @unless @isset @empty @auth @guest @production @env
+;; @can @cannot @canany @feature @hasSection @sectionMissing
+;; @error + custom @if-like directives
+;; ============================================================
+
+(conditional
+  (directive_start) @keyword)
+(conditional
+  (directive_end) @keyword)
+
+;; Conditional mid-keywords: @else @elseif @elseauth @elseguest etc.
+(conditional
+  (conditional_keyword
+    (directive) @keyword))
+
+;; ============================================================
+;; Loops — open/close + inner operators
+;; @for @foreach @forelse @while
+;; @continue @break @empty (inside @forelse)
+;; ============================================================
+
+(loop
+  (directive_start) @keyword)
+(loop
+  (directive_end) @keyword)
+(loop
+  (directive) @keyword)
+
+;; ============================================================
+;; Switch — @switch @case @break @default @endswitch
+;; ============================================================
+
+(switch
+  (directive_start) @keyword)
+(switch
+  (directive_end) @keyword)
+(switch
+  (directive) @keyword)
+
+;; ============================================================
+;; Sections — @section (block & inline) @endsection @show
+;; ============================================================
+
+(section
+  (directive_start) @function.method)
+(section
+  (directive_end) @function.method)
+(section
+  (directive) @function.method)
+
+;; ============================================================
+;; Stacks — @push @pushOnce @pushIf @prepend @prependOnce
+;;          @endpush @endPushOnce @endPushIf @endprepend @endPrependOnce
+;; ============================================================
+
+(stack
+  (directive_start) @function.method)
+(stack
+  (directive_end) @function.method)
+
+;; ============================================================
+;; @once @endonce
+;; ============================================================
+
+(once
+  (directive_start) @function.method)
+(once
+  (directive_end) @function.method)
+
+;; ============================================================
+;; @fragment @endfragment
+;; ============================================================
+
+(fragment
+  (directive_start) @function.method)
+(fragment
+  (directive_end) @function.method)
+
+;; ============================================================
+;; @verbatim @endverbatim
+;; ============================================================
+
+(verbatim
+  (directive_start) @function.method)
+(verbatim
+  (directive_end) @function.method)
+
+;; ============================================================
+;; Envoy — @task @story @before @after @error @success @finished
+;;         + notification directives: @slack @discord @telegram @microsoftTeams
+;; ============================================================
+
+(envoy
+  (directive_start) @function.macro)
+(envoy
+  (directive_end) @function.macro)
+(envoy
+  (directive) @function.macro)
+
+;; ============================================================
+;; Livewire — @persist @teleport @volt @script @assets
+;; ============================================================
+
+(livewire
+  (directive_start) @function.macro)
+(livewire
+  (directive_end) @function.macro)
+
+;; ============================================================
+;; PHP Statements — {{ }} {!! !!} @php() @php..@endphp @setup..@endsetup <?php ?>
+;; ============================================================
+
+(php_statement
+  (directive) @function.macro)
+(php_statement
+  (directive_start) @function.macro)
+(php_statement
+  (directive_end) @function.macro)
+
+(php_tag) @punctuation.bracket
+(php_end_tag) @punctuation.bracket
+
+;; ============================================================
+;; Blade Attribute Directives — @class @style @checked @selected
+;;                              @disabled @readonly @required
+;; ============================================================
+
+(attribute
+  (directive) @attribute)
+
+;; ============================================================
+;; Inline Directives — bare (directive) at document level
+;; @include @includeIf @includeWhen @includeUnless @includeFirst
+;; @extends @yield @method @inject @each @vite @livewire
+;; @aware @servers @import @js @svg @props @use @stack
+;; @asset @json @script @thumbnail @extract @set
+;; @field @options (ACF) @wireUiScripts (with params)
+;; + any custom directives matching @[a-zA-Z]+
+;; ============================================================
+
+(document (directive) @function.call)
+
+;; ============================================================
+;; Parameters (inside directive parentheses)
+;; ============================================================
+
+(parameter) @variable.parameter
+
+;; ============================================================
+;; Punctuation — echo brackets, parentheses
+;; ============================================================
+
 [
   "{{"
   "}}"

--- a/languages/blade/injections.scm
+++ b/languages/blade/injections.scm
@@ -5,6 +5,12 @@
     (#set! injection.include-children)
     (#set! injection.language "php_only"))
 
+; Envoy body text — inject as bash for @task/@story blocks
+((text) @injection.content
+    (#has-ancestor? @injection.content "envoy")
+    (#set! injection.combined)
+    (#set! injection.language "bash"))
+
 ; Livewire attributes
 ; <div wire:click="baz++">
 (attribute

--- a/languages/blade/outline.scm
+++ b/languages/blade/outline.scm
@@ -2,40 +2,38 @@
 ;; Blade Sections — show section name from parameter
 ;; ============================================================
 
+;; Block section: @section('sidebar') ... @endsection
 (section
   (directive_start) @_start
   (parameter) @name
-  (#gsub! @name "^['\"](.+)['\"]$" "%1"))
-(section) @item
+  (#gsub! @name "^['\"](.+)['\"]$" "%1")) @item
 
-;; Section with inline value: @section('title', 'Default')
+;; Inline section: @section('title', 'Default')
 (section
-  (directive) @name)
-(section) @item
+  (directive) @_directive
+  (parameter) @name
+  (#gsub! @name "^['\"](.+)['\"]$" "%1")) @item
 
 ;; ============================================================
 ;; Blade Conditionals — show @if, @auth, @can etc.
 ;; ============================================================
 
 (conditional
-  (directive_start) @name)
-(conditional) @item
+  (directive_start) @name) @item
 
 ;; ============================================================
 ;; Blade Loops — show @foreach, @for, @forelse, @while
 ;; ============================================================
 
 (loop
-  (directive_start) @name)
-(loop) @item
+  (directive_start) @name) @item
 
 ;; ============================================================
 ;; Blade Switch
 ;; ============================================================
 
 (switch
-  (directive_start) @name)
-(switch) @item
+  (directive_start) @name) @item
 
 ;; ============================================================
 ;; Blade Stacks — @push, @pushOnce, @pushIf, @prepend, @prependOnce
@@ -44,24 +42,20 @@
 (stack
   (directive_start) @_start
   (parameter) @name
-  (#gsub! @name "^['\"](.+)['\"]$" "%1"))
-(stack) @item
+  (#gsub! @name "^['\"](.+)['\"]$" "%1")) @item
 
 ;; ============================================================
 ;; Blade Once, Fragment, Verbatim
 ;; ============================================================
 
 (once
-  (directive_start) @name)
-(once) @item
+  (directive_start) @name) @item
 
 (fragment
-  (directive_start) @name)
-(fragment) @item
+  (directive_start) @name) @item
 
 (verbatim
-  (directive_start) @name)
-(verbatim) @item
+  (directive_start) @name) @item
 
 ;; ============================================================
 ;; PHP Blocks — @php ... @endphp
@@ -76,16 +70,14 @@
 ;; ============================================================
 
 (envoy
-  (directive_start) @name)
-(envoy) @item
+  (directive_start) @name) @item
 
 ;; ============================================================
 ;; Livewire Blocks
 ;; ============================================================
 
 (livewire
-  (directive_start) @name)
-(livewire) @item
+  (directive_start) @name) @item
 
 ;; ============================================================
 ;; HTML Elements

--- a/languages/blade/outline.scm
+++ b/languages/blade/outline.scm
@@ -1,6 +1,104 @@
+;; ============================================================
+;; Blade Sections — show section name from parameter
+;; ============================================================
+
+(section
+  (directive_start) @_start
+  (parameter) @name
+  (#gsub! @name "^['\"](.+)['\"]$" "%1"))
+(section) @item
+
+;; Section with inline value: @section('title', 'Default')
+(section
+  (directive) @name)
+(section) @item
+
+;; ============================================================
+;; Blade Conditionals — show @if, @auth, @can etc.
+;; ============================================================
+
+(conditional
+  (directive_start) @name)
+(conditional) @item
+
+;; ============================================================
+;; Blade Loops — show @foreach, @for, @forelse, @while
+;; ============================================================
+
+(loop
+  (directive_start) @name)
+(loop) @item
+
+;; ============================================================
+;; Blade Switch
+;; ============================================================
+
+(switch
+  (directive_start) @name)
+(switch) @item
+
+;; ============================================================
+;; Blade Stacks — @push, @pushOnce, @pushIf, @prepend, @prependOnce
+;; ============================================================
+
+(stack
+  (directive_start) @_start
+  (parameter) @name
+  (#gsub! @name "^['\"](.+)['\"]$" "%1"))
+(stack) @item
+
+;; ============================================================
+;; Blade Once, Fragment, Verbatim
+;; ============================================================
+
+(once
+  (directive_start) @name)
+(once) @item
+
+(fragment
+  (directive_start) @name)
+(fragment) @item
+
+(verbatim
+  (directive_start) @name)
+(verbatim) @item
+
+;; ============================================================
+;; PHP Blocks — @php ... @endphp
+;; ============================================================
+
+(php_statement
+  (directive_start) @name
+  (php_only)) @item
+
+;; ============================================================
+;; Envoy Blocks
+;; ============================================================
+
+(envoy
+  (directive_start) @name)
+(envoy) @item
+
+;; ============================================================
+;; Livewire Blocks
+;; ============================================================
+
+(livewire
+  (directive_start) @name)
+(livewire) @item
+
+;; ============================================================
+;; HTML Elements
+;; ============================================================
+
 (element
   (start_tag
     (tag_name) @name)) @item
 
-(directive) @name @item
-(directive_start) @name @item
+(script_element
+  (start_tag
+    (tag_name) @name)) @item
+
+(style_element
+  (start_tag
+    (tag_name) @name)) @item


### PR DESCRIPTION
## Changes
- Rewritten highlights.scm — ~85 Blade directives in 7 color groups
- New folds.scm — code folding for block directives + HTML
- Expanded outline.scm — sections by name, conditionals, loops, stacks, livewire, envoy
- Added bash injection for Envoy body text
- Added @ to word_characters in config.toml
- Updated README